### PR TITLE
chore: change e.printStackTrace to logging

### DIFF
--- a/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
+++ b/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
@@ -1,40 +1,36 @@
 /*
  * GoogleBaseImpl.java
- *
+ * 
  * Created on November 16, 2005, 2:06 PM
- *
- * This library is provided under dual licenses.
- * You may choose the terms of the Lesser General Public License or the Apache
- * License at your discretion.
- *
- *  Copyright (C) 2005  Robert Cooper, Temple of the Screaming Penguin
- *
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * 
+ * This library is provided under dual licenses. You may choose the terms of the Lesser General
+ * Public License or the Apache License at your discretion.
+ * 
+ * Copyright (C) 2005 Robert Cooper, Temple of the Screaming Penguin
+ * 
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version
+ * 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. * See the License for the specific language governing permissions and
- * limitations under the License.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with this library;
+ * if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307 USA
+ * 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. * See the License for the specific language governing permissions and limitations
+ * under the License.
  */
 package com.rometools.modules.base;
 
@@ -71,8 +67,8 @@ public class GoogleBaseImpl implements GoogleBase {
      *
      */
     private static final long serialVersionUID = 1L;
-    
-    private static final Logger	LOG	= LoggerFactory.getLogger(GoogleBaseImpl.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(GoogleBaseImpl.class);
 
     /** boolean:listing_type */
     private Boolean listingType;
@@ -1302,7 +1298,7 @@ public class GoogleBaseImpl implements GoogleBase {
 
             return gbi;
         } catch (final Exception e) {
-            LOG.error("Error",e);
+            LOG.error("Error", e);
             throw new CloneNotSupportedException();
         }
     }

--- a/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
+++ b/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
@@ -72,7 +72,7 @@ public class GoogleBaseImpl implements GoogleBase {
      */
     private static final long serialVersionUID = 1L;
     
-    private static final Logger		LOG	= LoggerFactory.getLogger(GoogleBaseImpl.class);
+    private static final Logger	LOG	= LoggerFactory.getLogger(GoogleBaseImpl.class);
 
     /** boolean:listing_type */
     private Boolean listingType;

--- a/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
+++ b/src/main/java/com/rometools/modules/base/GoogleBaseImpl.java
@@ -42,6 +42,9 @@ import java.lang.reflect.Array;
 import java.net.URL;
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.rometools.modules.base.types.CloneableType;
 import com.rometools.modules.base.types.CurrencyEnumeration;
 import com.rometools.modules.base.types.DateTimeRange;
@@ -68,6 +71,8 @@ public class GoogleBaseImpl implements GoogleBase {
      *
      */
     private static final long serialVersionUID = 1L;
+    
+    private static final Logger		LOG	= LoggerFactory.getLogger(GoogleBaseImpl.class);
 
     /** boolean:listing_type */
     private Boolean listingType;
@@ -1297,7 +1302,7 @@ public class GoogleBaseImpl implements GoogleBase {
 
             return gbi;
         } catch (final Exception e) {
-            e.printStackTrace();
+            LOG.error("Error",e);
             throw new CloneNotSupportedException();
         }
     }

--- a/src/main/java/com/rometools/modules/base/io/GoogleBaseGenerator.java
+++ b/src/main/java/com/rometools/modules/base/io/GoogleBaseGenerator.java
@@ -1,41 +1,36 @@
 /*
  * GoogleBaseGenerator.java
- *
+ * 
  * Created on November 17, 2005, 2:46 PM
- *
- * This library is provided under dual licenses.
- * You may choose the terms of the Lesser General Public License or the Apache
- * License at your discretion.
- *
- *  Copyright (C) 2005  Robert Cooper, Temple of the Screaming Penguin
- *
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * 
+ * This library is provided under dual licenses. You may choose the terms of the Lesser General
+ * Public License or the Apache License at your discretion.
+ * 
+ * Copyright (C) 2005 Robert Cooper, Temple of the Screaming Penguin
+ * 
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version
+ * 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with this library;
+ * if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307 USA
+ * 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.rometools.modules.base.io;
 
@@ -74,8 +69,8 @@ import com.rometools.rome.io.ModuleGenerator;
  */
 public class GoogleBaseGenerator implements ModuleGenerator {
     private static final Namespace NS = Namespace.getNamespace("g-core", GoogleBase.URI);
-    
-    private static final Logger	LOG	= LoggerFactory.getLogger(GoogleBaseGenerator.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(GoogleBaseGenerator.class);
 
     /** Creates a new instance of GoogleBaseGenerator */
     public GoogleBaseGenerator() {
@@ -113,7 +108,7 @@ public class GoogleBaseGenerator implements ModuleGenerator {
                 if (pd.getPropertyType().isArray()) {
                     values = (Object[]) pd.getReadMethod().invoke(mod, (Object[]) null);
                 } else {
-                    values = new Object[] { pd.getReadMethod().invoke(mod, (Object[]) null) };
+                    values = new Object[] {pd.getReadMethod().invoke(mod, (Object[]) null)};
                 }
 
                 for (int j = 0; values != null && j < values.length; j++) {
@@ -122,7 +117,7 @@ public class GoogleBaseGenerator implements ModuleGenerator {
                     }
                 }
             } catch (final Exception e) {
-               LOG.error("Error",e);
+                LOG.error("Error", e);
             }
         }
     }

--- a/src/main/java/com/rometools/modules/base/io/GoogleBaseGenerator.java
+++ b/src/main/java/com/rometools/modules/base/io/GoogleBaseGenerator.java
@@ -48,6 +48,8 @@ import java.util.Set;
 
 import org.jdom2.Element;
 import org.jdom2.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.rometools.modules.base.GoogleBase;
 import com.rometools.modules.base.GoogleBaseImpl;
@@ -72,6 +74,8 @@ import com.rometools.rome.io.ModuleGenerator;
  */
 public class GoogleBaseGenerator implements ModuleGenerator {
     private static final Namespace NS = Namespace.getNamespace("g-core", GoogleBase.URI);
+    
+    private static final Logger		LOG	= LoggerFactory.getLogger(GoogleBaseGenerator.class);
 
     /** Creates a new instance of GoogleBaseGenerator */
     public GoogleBaseGenerator() {
@@ -118,7 +122,7 @@ public class GoogleBaseGenerator implements ModuleGenerator {
                     }
                 }
             } catch (final Exception e) {
-                e.printStackTrace();
+               LOG.error("Error",e);
             }
         }
     }

--- a/src/main/java/com/rometools/modules/base/io/GoogleBaseGenerator.java
+++ b/src/main/java/com/rometools/modules/base/io/GoogleBaseGenerator.java
@@ -75,7 +75,7 @@ import com.rometools.rome.io.ModuleGenerator;
 public class GoogleBaseGenerator implements ModuleGenerator {
     private static final Namespace NS = Namespace.getNamespace("g-core", GoogleBase.URI);
     
-    private static final Logger		LOG	= LoggerFactory.getLogger(GoogleBaseGenerator.class);
+    private static final Logger	LOG	= LoggerFactory.getLogger(GoogleBaseGenerator.class);
 
     /** Creates a new instance of GoogleBaseGenerator */
     public GoogleBaseGenerator() {

--- a/src/main/java/com/rometools/modules/base/io/GoogleBaseParser.java
+++ b/src/main/java/com/rometools/modules/base/io/GoogleBaseParser.java
@@ -96,10 +96,8 @@ public class GoogleBaseParser implements ModuleParser {
             pds = Introspector.getBeanInfo(GoogleBaseImpl.class).getPropertyDescriptors();
             PROPS2TAGS.load(GoogleBaseParser.class.getResourceAsStream("/com/rometools/modules/base/io/tags.properties"));
         } catch (final IOException e) {
-            e.printStackTrace();
             LOG.error("Unable to read properties file for Google Base tags!", e);
         } catch (final IntrospectionException e) {
-            e.printStackTrace();
             LOG.error("Unable to get property descriptors for GoogleBaseImpl!", e);
         }
     }
@@ -144,7 +142,6 @@ public class GoogleBaseParser implements ModuleParser {
                         handleTag(child, pd, module);
                     } catch (final Exception e) {
                         LOG.warn("Unable to handle tag: " + child.getName(), e);
-                        e.printStackTrace();
                     }
                 }
             }

--- a/src/main/java/com/rometools/modules/base/io/GoogleBaseParser.java
+++ b/src/main/java/com/rometools/modules/base/io/GoogleBaseParser.java
@@ -1,41 +1,36 @@
 /*
  * GoogleBaseParser.java
- *
+ * 
  * Created on November 17, 2005, 11:31 AM
- *
- * This library is provided under dual licenses.
- * You may choose the terms of the Lesser General Public License or the Apache
- * License at your discretion.
- *
- *  Copyright (C) 2005  Robert Cooper, Temple of the Screaming Penguin
- *
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * 
+ * This library is provided under dual licenses. You may choose the terms of the Lesser General
+ * Public License or the Apache License at your discretion.
+ * 
+ * Copyright (C) 2005 Robert Cooper, Temple of the Screaming Penguin
+ * 
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version
+ * 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with this library;
+ * if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307 USA
+ * 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.rometools.modules.base.io;
 
@@ -195,12 +190,13 @@ public class GoogleBaseParser implements ModuleParser {
         } else if (pd.getPropertyType() == FloatUnit.class || pd.getPropertyType().getComponentType() == FloatUnit.class) {
             tagValue = new FloatUnit(tag.getText());
         } else if (pd.getPropertyType() == DateTimeRange.class || pd.getPropertyType().getComponentType() == DateTimeRange.class) {
-            tagValue = new DateTimeRange(LONG_DT_FMT.parse(tag.getChild("start", GoogleBaseParser.NS).getText().trim()), LONG_DT_FMT.parse(tag
-                    .getChild("end", GoogleBaseParser.NS).getText().trim()));
+            tagValue =
+                    new DateTimeRange(LONG_DT_FMT.parse(tag.getChild("start", GoogleBaseParser.NS).getText().trim()), LONG_DT_FMT.parse(tag
+                            .getChild("end", GoogleBaseParser.NS).getText().trim()));
         } else if (pd.getPropertyType() == ShippingType.class || pd.getPropertyType().getComponentType() == ShippingType.class) {
             final FloatUnit price = new FloatUnit(tag.getChild("price", GoogleBaseParser.NS).getText().trim());
-            ShippingType.ServiceEnumeration service = ShippingType.ServiceEnumeration
-                    .findByValue(tag.getChild("service", GoogleBaseParser.NS).getText().trim());
+            ShippingType.ServiceEnumeration service =
+                    ShippingType.ServiceEnumeration.findByValue(tag.getChild("service", GoogleBaseParser.NS).getText().trim());
 
             if (service == null) {
                 service = ShippingType.ServiceEnumeration.STANDARD;
@@ -223,7 +219,7 @@ public class GoogleBaseParser implements ModuleParser {
         }
 
         if (!pd.getPropertyType().isArray()) {
-            pd.getWriteMethod().invoke(module, new Object[] { tagValue });
+            pd.getWriteMethod().invoke(module, new Object[] {tagValue});
         } else {
             final Object[] current = (Object[]) pd.getReadMethod().invoke(module, (Object[]) null);
             final int newSize = current == null ? 1 : current.length + 1;
@@ -236,7 +232,7 @@ public class GoogleBaseParser implements ModuleParser {
             }
 
             Array.set(setValue, i, tagValue);
-            pd.getWriteMethod().invoke(module, new Object[] { setValue });
+            pd.getWriteMethod().invoke(module, new Object[] {setValue});
         }
     }
 }

--- a/src/main/java/com/rometools/modules/cc/types/License.java
+++ b/src/main/java/com/rometools/modules/cc/types/License.java
@@ -1,41 +1,36 @@
 /*
  * LicenseEnumeration.java
- *
+ * 
  * Created on November 20, 2005, 3:20 PM
- *
- * This library is provided under dual licenses.
- * You may choose the terms of the Lesser General Public License or the Apache
- * License at your discretion.
- *
- *  Copyright (C) 2005  Robert Cooper, Temple of the Screaming Penguin
- *
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * 
+ * This library is provided under dual licenses. You may choose the terms of the Lesser General
+ * Public License or the Apache License at your discretion.
+ * 
+ * Copyright (C) 2005 Robert Cooper, Temple of the Screaming Penguin
+ * 
+ * 
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version
+ * 2.1 of the License, or (at your option) any later version.
+ * 
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
- *
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License along with this library;
+ * if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307 USA
+ * 
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.rometools.modules.cc.types;
 
@@ -59,30 +54,30 @@ public class License {
 
     private static final String CC_START = "http://creativecommons.org/licenses/";
     private static final Map<String, License> lookupLicense = new ConcurrentHashMap<String, License>();
-    private static final Logger	LOG	= LoggerFactory.getLogger(License.class);
+    private static final Logger LOG = LoggerFactory.getLogger(License.class);
     public static final License NO_DERIVS = new License("http://creativecommons.org/licenses/nd/1.0/", new Behaviour[0], new Behaviour[] {
-            Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
+            Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
     public static final License NO_DERIVS_NONCOMMERCIAL = new License("http://creativecommons.org/licenses/nd-nc/1.0/",
-            new Behaviour[] { Behaviour.NONCOMMERCIAL }, new Behaviour[] { Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
-    public static final License NONCOMMERCIAL = new License("http://creativecommons.org/licenses/nc/1.0/", new Behaviour[] { Behaviour.NONCOMMERCIAL },
-            new Behaviour[] { Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
-    public static final License SHARE_ALIKE = new License("http://creativecommons.org/licenses/sa/1.0/", new Behaviour[] { Behaviour.COPYLEFT },
-            new Behaviour[] { Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
-    public static final License SHARE_ALIKE_NONCOMMERCIAL = new License("http://creativecommons.org/licenses/nc-sa/1.0/", new Behaviour[] { Behaviour.COPYLEFT,
-            Behaviour.NONCOMMERCIAL }, new Behaviour[] { Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
-    public static final License SHARE_ALIKE_ATTRIBUTION = new License("http://creativecommons.org/licenses/by-sa/2.5/", new Behaviour[] { Behaviour.COPYLEFT,
-            Behaviour.ATTRIBUTION }, new Behaviour[] { Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
+            new Behaviour[] {Behaviour.NONCOMMERCIAL}, new Behaviour[] {Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
+    public static final License NONCOMMERCIAL = new License("http://creativecommons.org/licenses/nc/1.0/", new Behaviour[] {Behaviour.NONCOMMERCIAL},
+            new Behaviour[] {Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
+    public static final License SHARE_ALIKE = new License("http://creativecommons.org/licenses/sa/1.0/", new Behaviour[] {Behaviour.COPYLEFT}, new Behaviour[] {
+            Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
+    public static final License SHARE_ALIKE_NONCOMMERCIAL = new License("http://creativecommons.org/licenses/nc-sa/1.0/", new Behaviour[] {Behaviour.COPYLEFT,
+            Behaviour.NONCOMMERCIAL}, new Behaviour[] {Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
+    public static final License SHARE_ALIKE_ATTRIBUTION = new License("http://creativecommons.org/licenses/by-sa/2.5/", new Behaviour[] {Behaviour.COPYLEFT,
+            Behaviour.ATTRIBUTION}, new Behaviour[] {Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
     public static final License SHARE_ALIKE_NONCOMMERCIAL_ATTRIBUTION = new License("http://creativecommons.org/licenses/by-nc-sa/2.5/", new Behaviour[] {
-            Behaviour.COPYLEFT, Behaviour.ATTRIBUTION, Behaviour.NONCOMMERCIAL }, new Behaviour[] { Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION,
-            Behaviour.REPRODUCTION });
+            Behaviour.COPYLEFT, Behaviour.ATTRIBUTION, Behaviour.NONCOMMERCIAL}, new Behaviour[] {Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION,
+            Behaviour.REPRODUCTION});
     public static final License NONCOMMERCIAL_ATTRIBUTION = new License("http://creativecommons.org/licenses/by-nc/2.5/", new Behaviour[] {
-            Behaviour.ATTRIBUTION, Behaviour.NONCOMMERCIAL }, new Behaviour[] { Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
+            Behaviour.ATTRIBUTION, Behaviour.NONCOMMERCIAL}, new Behaviour[] {Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
     public static final License NONCOMMERCIAL_ATTRIBUTION_NO_DERIVS = new License("http://creativecommons.org/licenses/by-nc-nd/2.5/", new Behaviour[] {
-            Behaviour.ATTRIBUTION, Behaviour.NONCOMMERCIAL }, new Behaviour[] { Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
-    public static final License ATTRIBUTION_NO_DERIVS = new License("http://creativecommons.org/licenses/by-nd/2.5/",
-            new Behaviour[] { Behaviour.ATTRIBUTION }, new Behaviour[] { Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
-    public static final License ATTRIBUTION = new License("http://creativecommons.org/licenses/by/2.5/", new Behaviour[] { Behaviour.ATTRIBUTION },
-            new Behaviour[] { Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
+            Behaviour.ATTRIBUTION, Behaviour.NONCOMMERCIAL}, new Behaviour[] {Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
+    public static final License ATTRIBUTION_NO_DERIVS = new License("http://creativecommons.org/licenses/by-nd/2.5/", new Behaviour[] {Behaviour.ATTRIBUTION},
+            new Behaviour[] {Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
+    public static final License ATTRIBUTION = new License("http://creativecommons.org/licenses/by/2.5/", new Behaviour[] {Behaviour.ATTRIBUTION},
+            new Behaviour[] {Behaviour.DERIVATIVE, Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION});
     private final String uri;
     private final Behaviour[] permits;
     private final Behaviour[] requires;
@@ -124,7 +119,7 @@ public class License {
                         }
                     }
                 } catch (final Exception e) {
-                	 LOG.error("Error",e);
+                    LOG.error("Error", e);
                 }
             }
         }

--- a/src/main/java/com/rometools/modules/cc/types/License.java
+++ b/src/main/java/com/rometools/modules/cc/types/License.java
@@ -48,7 +48,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.rome.feed.impl.EqualsBean;
 import com.rometools.rome.feed.impl.ToStringBean;
 
@@ -60,7 +59,7 @@ public class License {
 
     private static final String CC_START = "http://creativecommons.org/licenses/";
     private static final Map<String, License> lookupLicense = new ConcurrentHashMap<String, License>();
-    private static final Logger		LOG	= LoggerFactory.getLogger(License.class);
+    private static final Logger	LOG	= LoggerFactory.getLogger(License.class);
     public static final License NO_DERIVS = new License("http://creativecommons.org/licenses/nd/1.0/", new Behaviour[0], new Behaviour[] {
             Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
     public static final License NO_DERIVS_NONCOMMERCIAL = new License("http://creativecommons.org/licenses/nd-nc/1.0/",

--- a/src/main/java/com/rometools/modules/cc/types/License.java
+++ b/src/main/java/com/rometools/modules/cc/types/License.java
@@ -45,6 +45,10 @@ import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.rome.feed.impl.EqualsBean;
 import com.rometools.rome.feed.impl.ToStringBean;
 
@@ -56,6 +60,7 @@ public class License {
 
     private static final String CC_START = "http://creativecommons.org/licenses/";
     private static final Map<String, License> lookupLicense = new ConcurrentHashMap<String, License>();
+    private static final Logger		LOG	= LoggerFactory.getLogger(License.class);
     public static final License NO_DERIVS = new License("http://creativecommons.org/licenses/nd/1.0/", new Behaviour[0], new Behaviour[] {
             Behaviour.DISTRIBUTION, Behaviour.REPRODUCTION });
     public static final License NO_DERIVS_NONCOMMERCIAL = new License("http://creativecommons.org/licenses/nd-nc/1.0/",
@@ -120,7 +125,7 @@ public class License {
                         }
                     }
                 } catch (final Exception e) {
-                    e.printStackTrace();
+                	 LOG.error("Error",e);
                 }
             }
         }

--- a/src/main/java/com/rometools/modules/georss/GeoRSSModule.java
+++ b/src/main/java/com/rometools/modules/georss/GeoRSSModule.java
@@ -1,18 +1,15 @@
 /*
  * Copyright 2006 Marc Wick, geonames.org
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.rometools.modules.georss;
 
@@ -36,8 +33,8 @@ import com.rometools.rome.feed.module.ModuleImpl;
 public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
 
     private static final long serialVersionUID = 1L;
-    
-    private static final Logger	LOG	= LoggerFactory.getLogger(GeoRSSModule.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(GeoRSSModule.class);
 
     protected AbstractGeometry geometry;
 
@@ -122,6 +119,7 @@ public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
 
     /*
      * (non-Javadoc)
+     * 
      * @see com.rometools.rome.feed.CopyFrom#copyFrom(java.lang.Object)
      */
     @Override
@@ -131,7 +129,7 @@ public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
         try {
             geometry = (AbstractGeometry) geometry.clone();
         } catch (final CloneNotSupportedException ex) {
-        	LOG.error("Error",ex);
+            LOG.error("Error", ex);
         }
     }
 
@@ -144,7 +142,7 @@ public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
             }
             return retval;
         } catch (final Exception ex) {
-        	LOG.error("Error",ex);
+            LOG.error("Error", ex);
         }
         throw new CloneNotSupportedException();
     }

--- a/src/main/java/com/rometools/modules/georss/GeoRSSModule.java
+++ b/src/main/java/com/rometools/modules/georss/GeoRSSModule.java
@@ -20,7 +20,6 @@ import org.jdom2.Namespace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.modules.georss.geometries.AbstractGeometry;
 import com.rometools.modules.georss.geometries.Point;
 import com.rometools.modules.georss.geometries.Position;
@@ -38,7 +37,7 @@ public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
 
     private static final long serialVersionUID = 1L;
     
-    private static final Logger		LOG	= LoggerFactory.getLogger(GeoRSSModule.class);
+    private static final Logger	LOG	= LoggerFactory.getLogger(GeoRSSModule.class);
 
     protected AbstractGeometry geometry;
 

--- a/src/main/java/com/rometools/modules/georss/GeoRSSModule.java
+++ b/src/main/java/com/rometools/modules/georss/GeoRSSModule.java
@@ -17,7 +17,10 @@
 package com.rometools.modules.georss;
 
 import org.jdom2.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.modules.georss.geometries.AbstractGeometry;
 import com.rometools.modules.georss.geometries.Point;
 import com.rometools.modules.georss.geometries.Position;
@@ -34,6 +37,8 @@ import com.rometools.rome.feed.module.ModuleImpl;
 public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
 
     private static final long serialVersionUID = 1L;
+    
+    private static final Logger		LOG	= LoggerFactory.getLogger(GeoRSSModule.class);
 
     protected AbstractGeometry geometry;
 
@@ -127,7 +132,7 @@ public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
         try {
             geometry = (AbstractGeometry) geometry.clone();
         } catch (final CloneNotSupportedException ex) {
-            ex.printStackTrace();
+        	LOG.error("Error",ex);
         }
     }
 
@@ -140,7 +145,7 @@ public abstract class GeoRSSModule extends ModuleImpl implements Cloneable {
             }
             return retval;
         } catch (final Exception ex) {
-            ex.printStackTrace();
+        	LOG.error("Error",ex);
         }
         throw new CloneNotSupportedException();
     }

--- a/src/main/java/com/rometools/modules/opensearch/impl/OpenSearchModuleImpl.java
+++ b/src/main/java/com/rometools/modules/opensearch/impl/OpenSearchModuleImpl.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.modules.opensearch.OpenSearchModule;
 import com.rometools.modules.opensearch.entity.OSQuery;
 import com.rometools.rome.feed.CopyFrom;
@@ -33,7 +32,7 @@ import com.rometools.rome.feed.module.ModuleImpl;
  */
 public class OpenSearchModuleImpl extends ModuleImpl implements OpenSearchModule, Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Logger		LOG	= LoggerFactory.getLogger(OpenSearchModuleImpl.class);
+    private static final Logger	LOG	= LoggerFactory.getLogger(OpenSearchModuleImpl.class);
     private int totalResults = -1;
     private int startIndex = 1;
     private int itemsPerPage = -1;

--- a/src/main/java/com/rometools/modules/opensearch/impl/OpenSearchModuleImpl.java
+++ b/src/main/java/com/rometools/modules/opensearch/impl/OpenSearchModuleImpl.java
@@ -18,6 +18,10 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.modules.opensearch.OpenSearchModule;
 import com.rometools.modules.opensearch.entity.OSQuery;
 import com.rometools.rome.feed.CopyFrom;
@@ -29,6 +33,7 @@ import com.rometools.rome.feed.module.ModuleImpl;
  */
 public class OpenSearchModuleImpl extends ModuleImpl implements OpenSearchModule, Serializable {
     private static final long serialVersionUID = 1L;
+    private static final Logger		LOG	= LoggerFactory.getLogger(OpenSearchModuleImpl.class);
     private int totalResults = -1;
     private int startIndex = 1;
     private int itemsPerPage = -1;
@@ -142,7 +147,7 @@ public class OpenSearchModuleImpl extends ModuleImpl implements OpenSearchModule
             try {
                 getQueries().add((OSQuery) q.clone());
             } catch (final CloneNotSupportedException e) {
-                e.printStackTrace();
+            	 LOG.error("Error",e);
             }
         }
     }

--- a/src/main/java/com/rometools/modules/opensearch/impl/OpenSearchModuleImpl.java
+++ b/src/main/java/com/rometools/modules/opensearch/impl/OpenSearchModuleImpl.java
@@ -1,16 +1,13 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.rometools.modules.opensearch.impl;
 
@@ -32,7 +29,7 @@ import com.rometools.rome.feed.module.ModuleImpl;
  */
 public class OpenSearchModuleImpl extends ModuleImpl implements OpenSearchModule, Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Logger	LOG	= LoggerFactory.getLogger(OpenSearchModuleImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OpenSearchModuleImpl.class);
     private int totalResults = -1;
     private int startIndex = 1;
     private int itemsPerPage = -1;
@@ -133,6 +130,7 @@ public class OpenSearchModuleImpl extends ModuleImpl implements OpenSearchModule
 
     /*
      * (non-Javadoc)
+     * 
      * @see com.rometools.rome.feed.CopyFrom#copyFrom(java.lang.Object)
      */
     @Override
@@ -146,13 +144,14 @@ public class OpenSearchModuleImpl extends ModuleImpl implements OpenSearchModule
             try {
                 getQueries().add((OSQuery) q.clone());
             } catch (final CloneNotSupportedException e) {
-            	 LOG.error("Error",e);
+                LOG.error("Error", e);
             }
         }
     }
 
     /*
      * (non-Javadoc)
+     * 
      * @see com.rometools.rome.feed.CopyFrom#getInterface()
      */
     @Override

--- a/src/main/java/com/rometools/modules/sse/modules/Conflict.java
+++ b/src/main/java/com/rometools/modules/sse/modules/Conflict.java
@@ -1,16 +1,13 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.rometools.modules.sse.modules;
@@ -28,8 +25,8 @@ import com.rometools.rome.feed.rss.Item;
  */
 public class Conflict extends SSEModule {
     private static final long serialVersionUID = 1L;
-    
-    private static final Logger	LOG	= LoggerFactory.getLogger(Conflict.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(Conflict.class);
 
     public static final String CONFLICTS_NAME = "conflicts";
 
@@ -74,7 +71,7 @@ public class Conflict extends SSEModule {
             conflict.conflictItem = (Item) conflictItem.clone();
         } catch (final CloneNotSupportedException e) {
             // should not happen
-        	LOG.error("Error",e);
+            LOG.error("Error", e);
         }
     }
 

--- a/src/main/java/com/rometools/modules/sse/modules/Conflict.java
+++ b/src/main/java/com/rometools/modules/sse/modules/Conflict.java
@@ -17,6 +17,10 @@ package com.rometools.modules.sse.modules;
 
 import java.util.Date;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.rome.feed.CopyFrom;
 import com.rometools.rome.feed.rss.Item;
 
@@ -25,6 +29,8 @@ import com.rometools.rome.feed.rss.Item;
  */
 public class Conflict extends SSEModule {
     private static final long serialVersionUID = 1L;
+    
+    private static final Logger		LOG	= LoggerFactory.getLogger(Conflict.class);
 
     public static final String CONFLICTS_NAME = "conflicts";
 
@@ -69,7 +75,7 @@ public class Conflict extends SSEModule {
             conflict.conflictItem = (Item) conflictItem.clone();
         } catch (final CloneNotSupportedException e) {
             // should not happen
-            e.printStackTrace();
+        	LOG.error("Error",e);
         }
     }
 

--- a/src/main/java/com/rometools/modules/sse/modules/Conflict.java
+++ b/src/main/java/com/rometools/modules/sse/modules/Conflict.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.rometools.modules.base.GoogleBaseImpl;
 import com.rometools.rome.feed.CopyFrom;
 import com.rometools.rome.feed.rss.Item;
 
@@ -30,7 +29,7 @@ import com.rometools.rome.feed.rss.Item;
 public class Conflict extends SSEModule {
     private static final long serialVersionUID = 1L;
     
-    private static final Logger		LOG	= LoggerFactory.getLogger(Conflict.class);
+    private static final Logger	LOG	= LoggerFactory.getLogger(Conflict.class);
 
     public static final String CONFLICTS_NAME = "conflicts";
 

--- a/src/main/java/com/rometools/modules/sse/modules/SSEModule.java
+++ b/src/main/java/com/rometools/modules/sse/modules/SSEModule.java
@@ -19,6 +19,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jdom2.Namespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.rometools.rome.feed.CopyFrom;
 import com.rometools.rome.feed.module.Module;
@@ -29,6 +31,8 @@ import com.rometools.rome.feed.module.Module;
  */
 public abstract class SSEModule implements Module {
     private static final long serialVersionUID = 1L;
+    
+    private static final Logger		LOG	= LoggerFactory.getLogger(SSEModule.class);
 
     public static final String SSE_SCHEMA_URI = "http://www.microsoft.com/schemas/rss/sse";
 
@@ -61,11 +65,9 @@ public abstract class SSEModule implements Module {
             clone = this.getClass().newInstance();
             clone.copyFrom(this);
         } catch (final InstantiationException e) {
-            // TODO: use logging
-            e.printStackTrace();
+        	LOG.error("Error",e);
         } catch (final IllegalAccessException e) {
-            // TODO: use logging
-            e.printStackTrace();
+        	LOG.error("Error",e);
         }
         return clone;
     }

--- a/src/main/java/com/rometools/modules/sse/modules/SSEModule.java
+++ b/src/main/java/com/rometools/modules/sse/modules/SSEModule.java
@@ -32,7 +32,7 @@ import com.rometools.rome.feed.module.Module;
 public abstract class SSEModule implements Module {
     private static final long serialVersionUID = 1L;
     
-    private static final Logger		LOG	= LoggerFactory.getLogger(SSEModule.class);
+    private static final Logger	LOG	= LoggerFactory.getLogger(SSEModule.class);
 
     public static final String SSE_SCHEMA_URI = "http://www.microsoft.com/schemas/rss/sse";
 

--- a/src/main/java/com/rometools/modules/sse/modules/SSEModule.java
+++ b/src/main/java/com/rometools/modules/sse/modules/SSEModule.java
@@ -1,16 +1,13 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.rometools.modules.sse.modules;
 
@@ -31,8 +28,8 @@ import com.rometools.rome.feed.module.Module;
  */
 public abstract class SSEModule implements Module {
     private static final long serialVersionUID = 1L;
-    
-    private static final Logger	LOG	= LoggerFactory.getLogger(SSEModule.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(SSEModule.class);
 
     public static final String SSE_SCHEMA_URI = "http://www.microsoft.com/schemas/rss/sse";
 
@@ -65,9 +62,9 @@ public abstract class SSEModule implements Module {
             clone = this.getClass().newInstance();
             clone.copyFrom(this);
         } catch (final InstantiationException e) {
-        	LOG.error("Error",e);
+            LOG.error("Error", e);
         } catch (final IllegalAccessException e) {
-        	LOG.error("Error",e);
+            LOG.error("Error", e);
         }
         return clone;
     }


### PR DESCRIPTION
Change several classes to remove calls to printStackTrace of exceptions
and use instead of logging from SFL4J which is already used in the
project

Ammendment of previous commit so the format and whitespacing is the same