### PR TITLE
Support more itunes tags

### DIFF
--- a/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
+++ b/src/main/java/com/rometools/modules/itunes/AbstractITunesObject.java
@@ -40,6 +40,8 @@
  */
 package com.rometools.modules.itunes;
 
+import java.net.URL;
+
 /**
  * This is an abstract object that implements the attributes common across Feeds or Items in an
  * iTunes compatible RSS feed.
@@ -74,6 +76,7 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
     private String author;
     private boolean block;
     private boolean explicit;
+    private URL image;
     private String[] keywords;
     private String subtitle;
     private String summary;
@@ -166,6 +169,16 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
         this.explicit = explicit;
     }
 
+    @Override
+    public URL getImage() {
+        return image;
+    }
+
+    @Override
+    public void setImage(final URL image) {
+        this.image = image;
+    }
+
     /**
      * A list of keywords for this feed or entry
      *
@@ -239,6 +252,8 @@ public abstract class AbstractITunesObject implements ITunes, java.lang.Cloneabl
         sb.append(getBlock());
         sb.append(" Explicit: ");
         sb.append(getExplicit());
+        sb.append(" Image: ");
+        sb.append(getImage());
         sb.append(" Keywords: ");
 
         if (getKeywords() != null) {

--- a/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
+++ b/src/main/java/com/rometools/modules/itunes/EntryInformationImpl.java
@@ -43,6 +43,12 @@ package com.rometools.modules.itunes;
 import com.rometools.modules.itunes.types.Duration;
 import com.rometools.rome.feed.CopyFrom;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
 /**
  * This class contains information for iTunes podcast feeds that exist at the Item level.
  *
@@ -54,6 +60,9 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
      *
      */
     private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(EntryInformationImpl.class);
+
     private Duration duration;
     private boolean closedCaptioned;
     private Integer order;
@@ -120,6 +129,14 @@ public class EntryInformationImpl extends AbstractITunesObject implements EntryI
         }
 
         setExplicit(info.getExplicit());
+
+        try {
+            if (info.getImage() != null) {
+                setImage(new URL(info.getImage().toExternalForm()));
+            }
+        } catch (final MalformedURLException e) {
+            LOG.debug("Error copying URL:" + info.getImage(), e);
+        }
 
         if (info.getKeywords() != null) {
             setKeywords(info.getKeywords().clone());

--- a/src/main/java/com/rometools/modules/itunes/FeedInformation.java
+++ b/src/main/java/com/rometools/modules/itunes/FeedInformation.java
@@ -67,23 +67,13 @@ public interface FeedInformation extends ITunes {
      */
     public void setCategories(List<Category> categories);
 
-    /**
-     * Sets the URL for the image.
-     *
-     * NOTE: To specification images should be in PNG or JPEG format.
-     *
-     * @param image Sets the URL for the image.
-     */
-    public void setImage(URL image);
+    public boolean getComplete();
 
-    /**
-     * Returns the URL for the image.
-     *
-     * NOTE: To specification images should be in PNG or JPEG format.
-     *
-     * @return Returns the URL for the image.
-     */
-    public URL getImage();
+    public void setComplete(boolean complete);
+
+    public String getNewFeedUrl();
+
+    public void setNewFeedUrl(String newFeedUrl);
 
     /**
      * Sets the owner email address for the feed.

--- a/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
+++ b/src/main/java/com/rometools/modules/itunes/FeedInformationImpl.java
@@ -66,8 +66,9 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
 
     private String ownerName;
     private String ownerEmailAddress;
-    private URL image;
     private List<Category> categories;
+    private boolean complete;
+    private String newFeedUrl;
 
     /**
      * Creates a new instance of FeedInformationImpl
@@ -93,6 +94,26 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
     @Override
     public void setCategories(final List<Category> categories) {
         this.categories = categories;
+    }
+
+    @Override
+    public boolean getComplete() {
+        return complete;
+    }
+
+    @Override
+    public void setComplete(boolean complete) {
+        this.complete = complete;
+    }
+
+    @Override
+    public String getNewFeedUrl() {
+        return newFeedUrl;
+    }
+
+    @Override
+    public void setNewFeedUrl(String newFeedUrl) {
+        this.newFeedUrl = newFeedUrl;
     }
 
     /**
@@ -136,30 +157,6 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
     }
 
     /**
-     * Returns the URL for the image.
-     *
-     * NOTE: To specification images should be in PNG or JPEG format.
-     *
-     * @return Returns the URL for the image.
-     */
-    @Override
-    public URL getImage() {
-        return image;
-    }
-
-    /**
-     * Sets the URL for the image.
-     *
-     * NOTE: To specification images should be in PNG or JPEG format.
-     *
-     * @param image Sets the URL for the image.
-     */
-    @Override
-    public void setImage(final URL image) {
-        this.image = image;
-    }
-
-    /**
      * Required by the ROME API
      *
      * @param obj object to copy property values from
@@ -175,6 +172,8 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
             getCategories().addAll(info.getCategories());
         }
 
+        setComplete(info.getComplete());
+        setNewFeedUrl(info.getNewFeedUrl());
         setExplicit(info.getExplicit());
 
         try {
@@ -215,10 +214,12 @@ public class FeedInformationImpl extends AbstractITunesObject implements FeedInf
         sb.append(getOwnerEmailAddress());
         sb.append(" name: ");
         sb.append(getOwnerName());
-        sb.append(" image: ");
-        sb.append(getImage());
         sb.append(" categories: ");
         sb.append(getCategories());
+        sb.append(" complete: ");
+        sb.append(getComplete());
+        sb.append(" newFeedUrl: ");
+        sb.append(getNewFeedUrl());
         sb.append("]");
         sb.append(super.toString());
 

--- a/src/main/java/com/rometools/modules/itunes/ITunes.java
+++ b/src/main/java/com/rometools/modules/itunes/ITunes.java
@@ -42,6 +42,8 @@ package com.rometools.modules.itunes;
 
 import com.rometools.rome.feed.module.Module;
 
+import java.net.URL;
+
 /**
  * This interface contains the methods common to all iTunes module points.
  *
@@ -93,6 +95,10 @@ public interface ITunes extends Module {
      * @param explicit Boolean as to whether this feed or entry contains adult content
      */
     public void setExplicit(boolean explicit);
+
+    public URL getImage();
+
+    public void setImage(URL image);
 
     /**
      * A list of keywords for this feed or entry

--- a/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
+++ b/src/main/java/com/rometools/modules/itunes/io/ITunesGenerator.java
@@ -98,12 +98,6 @@ public class ITunesGenerator implements ModuleGenerator {
             owner.addContent(name);
             element.addContent(owner);
 
-            if (info.getImage() != null) {
-                final Element image = generateSimpleElement("image", "");
-                image.setAttribute("href", info.getImage().toExternalForm());
-                element.addContent(image);
-            }
-
             final List<Category> categories = info.getCategories();
             for (final Category cat : categories) {
 
@@ -118,6 +112,15 @@ public class ITunesGenerator implements ModuleGenerator {
 
                 element.addContent(category);
             }
+
+            if (info.getComplete()) {
+                element.addContent(generateSimpleElement("complete", "yes"));
+            }
+
+            if (info.getNewFeedUrl() != null) {
+                element.addContent(generateSimpleElement("new-feed-url", info.getNewFeedUrl()));
+            }
+
         } else if (itunes instanceof EntryInformationImpl) {
             final EntryInformationImpl info = (EntryInformationImpl) itunes;
 
@@ -144,6 +147,12 @@ public class ITunesGenerator implements ModuleGenerator {
             element.addContent(generateSimpleElement("explicit", "yes"));
         } else {
             element.addContent(generateSimpleElement("explicit", "no"));
+        }
+
+        if (itunes.getImage() != null) {
+            final Element image = generateSimpleElement("image", "");
+            image.setAttribute("href", itunes.getImage().toExternalForm());
+            element.addContent(image);
         }
 
         if (itunes.getKeywords() != null) {

--- a/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
+++ b/src/main/java/com/rometools/modules/itunes/io/ITunesParser.java
@@ -109,17 +109,6 @@ public class ITunesParser implements ModuleParser {
                 }
             }
 
-            final Element image = element.getChild("image", ns);
-
-            if (image != null && image.getAttributeValue("href") != null) {
-                try {
-                    final URL imageURL = new URL(image.getAttributeValue("href").trim());
-                    feedInfo.setImage(imageURL);
-                } catch (final MalformedURLException e) {
-                    LOG.debug("Malformed URL Exception reading itunes:image tag: {}", image.getAttributeValue("href"));
-                }
-            }
-
             final List<Element> categories = element.getChildren("category", ns);
             for (final Element element2 : categories) {
                 final Element category = element2;
@@ -137,6 +126,16 @@ public class ITunesParser implements ModuleParser {
 
                     feedInfo.getCategories().add(cat);
                 }
+            }
+
+            final Element complete = element.getChild("complete", ns);
+            if (complete != null) {
+                feedInfo.setComplete("yes".equals(complete.getTextTrim().toLowerCase()));
+            }
+
+            final Element newFeedUrl = element.getChild("new-feed-url", ns);
+            if (newFeedUrl != null) {
+                feedInfo.setNewFeedUrl(newFeedUrl.getTextTrim());
             }
 
         } else if (element.getName().equals("item")) {
@@ -208,6 +207,17 @@ public class ITunesParser implements ModuleParser {
 
             if (summary != null) {
                 module.setSummary(summary.getTextTrim());
+            }
+
+            final Element image = element.getChild("image", ns);
+
+            if (image != null && image.getAttributeValue("href") != null) {
+                try {
+                    final URL imageURL = new URL(image.getAttributeValue("href").trim());
+                    module.setImage(imageURL);
+                } catch (final MalformedURLException e) {
+                    LOG.debug("Malformed URL Exception reading itunes:image tag: {}", image.getAttributeValue("href"));
+                }
             }
         }
 

--- a/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
+++ b/src/test/java/com/rometools/modules/itunes/ITunesParserTest.java
@@ -81,6 +81,8 @@ public class ITunesParserTest extends AbstractTestCase {
                 "summary",
                 "A weekly, hour-long romp through the worlds of media, politics, sports and show business, leavened with an eclectic mix of mysterious music, hosted by Harry Shearer.",
                 feedInfo.getSummary());
+        assertEquals(true, feedInfo.getComplete());
+        assertEquals("http://example.org", feedInfo.getNewFeedUrl());
 
         List<SyndEntry> entries = syndfeed.getEntries();
         Iterator<SyndEntry> it = entries.iterator();
@@ -116,5 +118,6 @@ public class ITunesParserTest extends AbstractTestCase {
         EntryInformationImpl entryInfo = (EntryInformationImpl) entry.getModule(AbstractITunesObject.URI);
         assertEquals(true, entryInfo.getClosedCaptioned());
         assertEquals(Integer.valueOf(2), entryInfo.getOrder());
+        assertEquals("http://example.org/image.png", entryInfo.getImage().toString());
     }
 }

--- a/src/test/resources/xml/leshow.xml
+++ b/src/test/resources/xml/leshow.xml
@@ -7,6 +7,8 @@
         <description>A weekly, hour-long romp through the worlds of media, politics, sports and show business, leavened with an eclectic mix of mysterious music, hosted by Harry Shearer.</description>
         <itunes:subtitle>An hour&#39;s worth of Harry Shearer</itunes:subtitle>
         <itunes:summary>A weekly, hour-long romp through the worlds of media, politics, sports and show business, leavened with an eclectic mix of mysterious music, hosted by Harry Shearer.</itunes:summary>
+        <itunes:complete>yes</itunes:complete>
+        <itunes:new-feed-url>http://example.org</itunes:new-feed-url>
         <language>en</language>
         
             <copyright>KCRW 2005</copyright>
@@ -68,6 +70,7 @@
     <itunes:keywords></itunes:keywords>  
     <itunes:isClosedCaptioned>yes</itunes:isClosedCaptioned>
     <itunes:order>2</itunes:order>
+    <itunes:image href="http://example.org/image.png"></itunes:image>
 </item>
 
         


### PR DESCRIPTION
`<itunes:image>`
---
Added support for it on entry. It was already implemented for feed, so I pulled it up from `FeedInformationImpl` to `AbstractITunesObject `. Used `URL` for consistency.

`<itunes:complete>`
---
Added support on feed. Type is `boolean`. When `true` results in `<itunes:complete>yes<itunes:complete>`. When `false` results in nothing.

`<itunes:new-feed-url>`
---
Added support on feed. When not `null` results in `<itunes:new-feed-url>http://example.com<itunes:new-feed-url>`. I used `String` instead of `URL`, because I don't see why Rome should care about the contents of the string.

`<itunes:explicit>`
---
I didn't add support for `clean` value to not break backwards compatibility.

Fixes most of #11 (except for `explicit`).